### PR TITLE
Refactoring to eliminate stream blocking

### DIFF
--- a/simple-java-example/src/main/java/com/example/eventhub/eventprocessor/single/EventProcessorSourceGraph.java
+++ b/simple-java-example/src/main/java/com/example/eventhub/eventprocessor/single/EventProcessorSourceGraph.java
@@ -1,9 +1,11 @@
 package com.example.eventhub.eventprocessor.single;
 
+import akka.japi.function.Procedure;
 import akka.stream.Attributes;
 import akka.stream.Outlet;
 import akka.stream.SourceShape;
 import akka.stream.stage.AbstractOutHandler;
+import akka.stream.stage.AsyncCallback;
 import akka.stream.stage.GraphStage;
 import akka.stream.stage.GraphStageLogic;
 import com.azure.messaging.eventhubs.EventProcessorClient;
@@ -18,6 +20,9 @@ import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
 
 class EventProcessorSourceGraph extends GraphStage<SourceShape<EventOrErrorContext>> {
 
@@ -54,9 +59,47 @@ class EventProcessorSourceGraph extends GraphStage<SourceShape<EventOrErrorConte
             private EventProcessorClient eventProcessorClient;
 
             private final BlockingQueue<EventOrErrorContext> blockingQueue = new LinkedBlockingDeque<>(MaxBufferedEventContexts);
+            private final ReentrantLock lock = new ReentrantLock();
+            private final Condition shouldPush = lock.newCondition();
+            private final Condition isInitialized = lock.newCondition();
+            private final AtomicBoolean stopping = new AtomicBoolean(false);
+            private AsyncCallback<EventOrErrorContext> pushCallback;
 
             @Override
             public void preStart() throws Exception {
+                pushCallback = createAsyncCallback(
+                        (Procedure<EventOrErrorContext>) param -> {
+                            push(out, param);
+                        }
+                );
+
+                // We first acquire the lock and wait for the blockingQueueThread to report that it has entered the lock and is awaiting its signal.
+                // Then we can release the lock and allow preStart to finish.
+                // This ensures that onPull is not called before blockingQueueThread is awaiting its signal.
+                lock.lock();
+                try {
+                    var blockingQueueThread = new Thread(() -> {
+                        final ReentrantLock lock = this.lock;
+                        lock.lock();
+                        isInitialized.signal();
+                        try {
+                            while (!stopping.get()) {
+                                this.shouldPush.await();
+                                var head = blockingQueue.take();
+                                pushCallback.invoke(head);
+                            }
+                        } catch (InterruptedException e) {
+                            throw new RuntimeException(e);
+                        } finally {
+                            lock.unlock();
+                        }
+                    });
+                    blockingQueueThread.start();
+                    isInitialized.await();
+                } finally {
+                    lock.unlock();
+                }
+
                 this.eventProcessorClient = new EventProcessorClientBuilder()
                         .connectionString(eventHubConfig.connectionString())
                         .eventHubName(eventHubConfig.eventHubName())
@@ -86,6 +129,7 @@ class EventProcessorSourceGraph extends GraphStage<SourceShape<EventOrErrorConte
             public void postStop() throws Exception {
                 logger.info("Stopping the EventProcessorSource");
                 this.eventProcessorClient.stop();
+                stopping.set(true);
                 super.postStop();
             }
 
@@ -93,9 +137,13 @@ class EventProcessorSourceGraph extends GraphStage<SourceShape<EventOrErrorConte
                 setHandler(out,
                         new AbstractOutHandler() {
                             @Override
-                            public void onPull() throws Exception {
-                                var head = blockingQueue.take();
-                                push(out, head);
+                            public void onPull() {
+                                lock.lock();
+                                try {
+                                    shouldPush.signal();
+                                } finally {
+                                    lock.unlock();
+                                }
                             }
 
                             @Override


### PR DESCRIPTION
We ran into some issues where the blocking queue was causing some weird blocking issues with the whole Akka stream. Moving most of the queue pull operations to a background thread and pushing downstream with an async callback got rid of the issues.